### PR TITLE
[ADD] Missing quotation mark (Explain XKCD wiki)

### DIFF
--- a/Web/xkcd.1h.sh
+++ b/Web/xkcd.1h.sh
@@ -23,6 +23,6 @@ echo "| image=$IMAGE"
 echo ---
 echo "$TITLE | size=14 href='https://www.xkcd.com/$IMG_RAND/'"
 echo "${SUB_TITLE}"
-echo "Explain XKCD wiki | href='https://www.explainxkcd.com/$IMG_RAND"
+echo "Explain XKCD wiki | href='https://www.explainxkcd.com/$IMG_RAND'"
 echo ---
 echo "Refresh... | refresh=true"


### PR DESCRIPTION
Add a Missing quotation mark on Explain XKCD wiki URL to make href working properly